### PR TITLE
[sailfishapp_priv] Set application name to fix QStandardPaths

### DIFF
--- a/docs/documentation.mdown
+++ b/docs/documentation.mdown
@@ -81,16 +81,24 @@ and the naming requirements for Harbour QA.
 Storing application configuration files
 ---------------------------------------
 
-TODO: Describe how to use <code>$XDG_CONFIG_HOME/$$TARGET</code> and
-the convenience method libsailfishapp will provide for that. Also
-describe how this data is managed by the system (cleaned, backed up,
-etc..). Also describe best practices for copying defaults from the
-system-wide data folder into the configuration folder at first start.
+To store application configuration files, you can use the standard
+<code>QSettings</code> class with the default constructor, which
+will use the application and organization name (set correctly by
+libsailfishapp to the application name, which is the binary name in
+case of C++ applications or the first argument in case of QML-only
+applications with the <code>sailfish-qml</code> launcher).
 
-Storing application data
-------------------------
+Storing application data and cached files
+-----------------------------------------
 
-TODO: Describe how to use <code>$XDG_DATA_HOME/$$TARGET</code> and the
-convenience method libsailfishapp will provide for that. Also describe
-(like above) what will happen with this data (backup, cleanup, ...).
+To store application data, use the location returned by
+<code>QStandardPaths::writableLocation(QStandardPaths::DataLocation)</code>
 
+To store cache files (these files can be removed at any time by the
+system if disk space is low, and these files are not guaranteed to
+be backed up), use the location returned by
+<code>QStandardPaths::writableLocation(QStandardPaths::CacheLocation)</codE>
+
+You can also use the Qt Quick Local Storage API to store data directly
+from your QML-only Sailfish Application. libsailfishapp will make sure
+that your application uses a application-specific storage directory.

--- a/sailfishapp.pro
+++ b/sailfishapp.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = src docs data launcher
+SUBDIRS = src docs data launcher tests

--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -29,6 +29,7 @@
 #include "sailfishapp_priv.h"
 
 #include <QCoreApplication>
+#include <QGuiApplication>
 #include <QString>
 #include <QFileInfo>
 #include <QDir>
@@ -75,6 +76,22 @@ QString dataDir()
     return QDir::cleanPath(QString("%1/%2")
         .arg(exe.absoluteDir().filePath("../share"))
         .arg(appName()));
+}
+
+QGuiApplication *
+configureApp(QGuiApplication *app)
+{
+    // We need to set the appName, so the following features will use
+    // the right application name for the data directory:
+    //
+    //  - QStandardPaths (::DataLocation, ::CacheLocation)
+    //  - QSettings (with default organization/application name)
+    //  - Qt Quick Local Storage (QQmlEngine::offlineStoragePath())
+
+    app->setOrganizationName(appName());
+    app->setOrganizationDomain(appName());
+    app->setApplicationName(appName());
+    return app;
 }
 
 }; /* namespace SailfishAppPriv */

--- a/src/sailfishapp_priv.h
+++ b/src/sailfishapp_priv.h
@@ -45,6 +45,7 @@ namespace SailfishAppPriv {
     // Non-backend-specific functions
     QString appName();
     QString dataDir();
+    QGuiApplication *configureApp(QGuiApplication *app);
 
     // Only used by launcher - please don't use in 3rd party apps
     SAILFISHAPP_EXPORT void _PrivateAPI_DoNotUse_setAppName(QString appName);

--- a/src/sailfishapp_priv_boosted.cpp
+++ b/src/sailfishapp_priv_boosted.cpp
@@ -35,7 +35,7 @@ namespace SailfishAppPriv {
 
 QGuiApplication *application(int &argc, char **argv)
 {
-    return MDeclarativeCache::qApplication(argc, argv);
+    return configureApp(MDeclarativeCache::qApplication(argc, argv));
 }
 
 QQuickView *view()

--- a/src/sailfishapp_priv_default.cpp
+++ b/src/sailfishapp_priv_default.cpp
@@ -36,7 +36,7 @@ namespace SailfishAppPriv {
 
 QGuiApplication *application(int &argc, char **argv)
 {
-    return new QGuiApplication(argc, argv);
+    return configureApp(new QGuiApplication(argc, argv));
 }
 
 QQuickView *view()

--- a/tests/storage_locations/README
+++ b/tests/storage_locations/README
@@ -1,0 +1,1 @@
+Test storage locations

--- a/tests/storage_locations/storage_locations.cpp
+++ b/tests/storage_locations/storage_locations.cpp
@@ -1,0 +1,68 @@
+
+/**
+ *
+ * Copyright (C) 2014 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jolla.com>
+ * All rights reserved.
+ *
+ * This file is part of libsailfishapp
+ *
+ * You may use this file under the terms of the GNU Lesser General
+ * Public License version 2.1 as published by the Free Software Foundation
+ * and appearing in the file license.lgpl included in the packaging
+ * of this file.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * and appearing in the file license.lgpl included in the packaging
+ * of this file.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ **/
+
+
+#include "sailfishapp.h"
+#include "sailfishapp_priv.h"
+
+#include <QCoreApplication>
+#include <QStandardPaths>
+#include <QSettings>
+#include <QQmlEngine>
+#include <QDebug>
+#include <QDir>
+
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication *app = SailfishApp::application(argc, argv);
+
+    qDebug() << "== QCoreApplication ==";
+    qDebug() << "Organization:" << QCoreApplication::organizationName();
+    qDebug() << "Application:" << QCoreApplication::applicationName();
+
+    qDebug() << "== QStandardPaths ==";
+    qDebug() << "Writable data:" << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    qDebug() << "Writable cache:" << QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+
+    // QStandardPaths::ConfigLocation only tells us the generic config
+    // location; in order to get the application-specific location, we
+    // append the QCoreApplication::applicationName() to it (we could
+    // also use QCoreApplication::organizationName(), as both are set
+    // by libsailfishapp so that Qt always uses the right paths)
+    qDebug() << "== Target paths ==";
+    qDebug() << "Config goes into:" << QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation))
+        .filePath(QCoreApplication::applicationName());
+
+    qDebug() << "== QSettings ==";
+    qDebug() << "File name:" << QSettings().fileName();
+
+    qDebug() << "== QQmlEngine ==";
+    qDebug() << "Offline storage path:" << QQmlEngine().offlineStoragePath();
+
+    return 0;
+}

--- a/tests/storage_locations/storage_locations.pro
+++ b/tests/storage_locations/storage_locations.pro
@@ -1,0 +1,11 @@
+QT += quick qml
+
+INCLUDEPATH += ../../include ../../src
+
+SOURCES += storage_locations.cpp
+
+LIBS += -L../../src -lsailfishapp
+
+# Always use booster
+CONFIG += link_pkgconfig
+PKGCONFIG += qdeclarative5-boostable


### PR DESCRIPTION
This will fix problems with the data directory and QStandardPaths when using the QML-only launcher.
