### PR TITLE
Spec version + namespace semicolons

### DIFF
--- a/include/sailfishapp.h
+++ b/include/sailfishapp.h
@@ -44,7 +44,8 @@ class QString;
 #  define SAILFISHAPP_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace SailfishApp {
+namespace SailfishApp
+{
     // Simple interface: Get boosted application and view
     SAILFISHAPP_EXPORT QGuiApplication *application(int &argc, char **argv);
     SAILFISHAPP_EXPORT QQuickView *createView();
@@ -57,7 +58,7 @@ namespace SailfishApp {
 
     // Very simple interface: Uses "qml/<appname>.qml" as QML entry point
     SAILFISHAPP_EXPORT int main(int &argc, char **argv);
-};
+}
 
 /* Forward-declare that main() is exportable (needed for booster) */
 Q_DECL_EXPORT int main(int argc, char *argv[]);

--- a/rpm/libsailfishapp.spec
+++ b/rpm/libsailfishapp.spec
@@ -1,5 +1,5 @@
 Name: libsailfishapp
-Version: 0
+Version: 1
 Release: 1
 Summary: Sailfish Application Library
 Group: Development/Libraries

--- a/src/sailfishapp.cpp
+++ b/src/sailfishapp.cpp
@@ -41,7 +41,8 @@
 #include <QQmlEngine>
 
 
-namespace SailfishApp {
+namespace SailfishApp
+{
 
 QGuiApplication *application(int &argc, char **argv)
 {
@@ -93,4 +94,4 @@ int main(int &argc, char **argv)
     return app->exec();
 }
 
-}; /* namespace SailfishApp */
+}

--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -55,7 +55,8 @@ static QString applicationPath()
 
 static QString customAppName;
 
-namespace SailfishAppPriv {
+namespace SailfishAppPriv
+{
 
 void _PrivateAPI_DoNotUse_setAppName(QString appName)
 {
@@ -139,4 +140,4 @@ configureView(QQuickView *view)
     return view;
 }
 
-}; /* namespace SailfishAppPriv */
+}

--- a/src/sailfishapp_priv.h
+++ b/src/sailfishapp_priv.h
@@ -37,7 +37,8 @@
 class QGuiApplication;
 class QQuickView;
 
-namespace SailfishAppPriv {
+namespace SailfishAppPriv
+{
     // Backend-specific (booster, non-booster) functions
     QGuiApplication *application(int &argc, char **argv);
     QQuickView *view();

--- a/src/sailfishapp_priv_boosted.cpp
+++ b/src/sailfishapp_priv_boosted.cpp
@@ -31,7 +31,8 @@
 #include <MDeclarativeCache>
 
 
-namespace SailfishAppPriv {
+namespace SailfishAppPriv
+{
 
 QGuiApplication *application(int &argc, char **argv)
 {
@@ -43,4 +44,4 @@ QQuickView *view()
     return configureView(MDeclarativeCache::qQuickView());
 }
 
-}; /* namespace SailfishAppPriv */
+}

--- a/src/sailfishapp_priv_default.cpp
+++ b/src/sailfishapp_priv_default.cpp
@@ -32,7 +32,8 @@
 #include <QQuickView>
 
 
-namespace SailfishAppPriv {
+namespace SailfishAppPriv
+{
 
 QGuiApplication *application(int &argc, char **argv)
 {
@@ -44,4 +45,4 @@ QQuickView *view()
     return configureView(new QQuickView);
 }
 
-}; /* namespace SailfishAppPriv */
+}


### PR DESCRIPTION
Version was removed from other PR but I think we should have it. Otherwise compilation on sb2 produces wrong .so.0 

@rainemak @martyone 