### PR TITLE
[libsailfishapp] Set application name for sandboxed apps. Fixes JB#52151

### DIFF
--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -96,9 +96,24 @@ configureApp(QGuiApplication *app)
     //  - Qt Quick Local Storage (QQmlEngine::offlineStoragePath())
 
     QString name = appName();
-    app->setOrganizationName(name);
-    app->setOrganizationDomain(name);
-    app->setApplicationName(name);
+
+    MDesktopEntry entry(QStandardPaths::locate(
+                QStandardPaths::ApplicationsLocation, appName() + ".desktop"));
+    if (entry.isSandboxed()) {
+        const auto section = QStringLiteral("X-Sailjail");
+        QString organizationName = entry.value(section, "OrganizationName");
+        if (organizationName.isEmpty())
+            organizationName = name;
+        app->setOrganizationName(organizationName);
+        app->setOrganizationDomain(organizationName);
+        QString applicationName = entry.value(section, "ApplicationName");
+        app->setApplicationName(
+                applicationName.isEmpty() ? name : applicationName);
+    } else {
+        app->setOrganizationName(name);
+        app->setOrganizationDomain(name);
+        app->setApplicationName(name);
+    }
 
     // Automatic i18n support. Translations are supposed to be named
     // "<appname>-<lang>.qm" in "/usr/share/<appname>/translations/"

--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -38,6 +38,7 @@
 #include <QTranslator>
 #include <QQuickView>
 #include <MDesktopEntry>
+#include <QStandardPaths>
 
 
 static QString applicationPath()
@@ -123,7 +124,8 @@ configureView(QQuickView *view)
         return NULL;
     }
 
-    MDesktopEntry entry("/usr/share/applications/" + appName() + ".desktop");
+    MDesktopEntry entry(QStandardPaths::locate(
+                QStandardPaths::ApplicationsLocation, appName() + ".desktop"));
     if (entry.isValid()) {
         view->setTitle(entry.name());
     }


### PR DESCRIPTION
If sandboxed app defines application name or organization name in their
desktop entry file, use those values. Otherwise old behavior is
retained.