### PR TITLE
[libsailfishapp] Requires qt5-qttools-linguist in devel.

### DIFF
--- a/rpm/libsailfishapp.spec
+++ b/rpm/libsailfishapp.spec
@@ -25,6 +25,7 @@ updated by the vendor.
 Summary: Development library for Sailfish apps
 Requires: %{name} = %{version}
 Requires: pkgconfig(qdeclarative5-boostable)
+Requires: qt5-qttools-linguist
 
 %description devel
 This package contains the development library for %{name}.


### PR DESCRIPTION
Since the devel package is installing .prf
files that depends on lupdate and lrelease,
make libsailfishapp-devel requires the
package that contains them.

Close #46 

Related forum entry: https://forum.sailfishos.org/t/translations-not-created-in-obs/18118

This is a suggestion. Another possibility is to fix the documentation on the website.